### PR TITLE
CI: bump checkout/setup-node to v5 (drop deprecated Node 20)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
GitHub is [deprecating Node 20 on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). The v1.7.0 publish run logged a warning that \`actions/checkout@v4\` and \`actions/setup-node@v4\` were force-run on Node 24.

This bumps both actions to their v5 tags in \`build.yml\` and \`publish.yml\` to run on Node 24 natively and clear the warning. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)